### PR TITLE
config JWT verification and OIDC header

### DIFF
--- a/config/jwt-checker.yaml
+++ b/config/jwt-checker.yaml
@@ -1,0 +1,16 @@
+# policy for JWT Verification. All services listed in targets field would require JWT token
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "jwt-example"
+spec:
+  targets:
+    - name: kernel-service-poc-service
+  peers:
+    - mtls:
+        mode: PERMISSIVE
+  origins:
+    - jwt:
+        issuer: "https://kernel.integ.envs.broadinstitute.org/"
+        jwksUri: "https://kernel.integ.envs.broadinstitute.org/.well-known/jwks.json"
+  principalBinding: USE_ORIGIN

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -2,3 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 commonLabels:
   app: env-base
+resources:
+  - jwt-checker.yaml
+  - request-header-checker.yaml
+

--- a/config/request-header-checker.yaml
+++ b/config/request-header-checker.yaml
@@ -1,0 +1,24 @@
+# Define a rule to reject all request if oidc_access_token is presented in request header.
+apiVersion: "config.istio.io/v1alpha2"
+kind: denier
+metadata:
+  name: denyall
+spec:
+  status:
+    code: 7
+    message: Not allowed
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: checknothing
+metadata:
+  name: denyoidc
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: header-rule
+spec:
+  match: match(request.headers["oidc_access_token"], ".+")
+  actions:
+    - handler: denyall.denier
+      instances: [ denyoidc.checknothing ]


### PR DESCRIPTION
With this change, kernel-service-poc would expect a valid jwt token signed by IC. 
And all service can not have oidc in their request header.

Test: curl -I --request POST   --url 'http://34.71.179.202/yyu-kernel-service-poc/api/template/v1/ping?message=foo'   --header 'content-type: ap
plication/json' -H  